### PR TITLE
Add login guard and return redirect for discount form

### DIFF
--- a/controllers/SubscriberController.php
+++ b/controllers/SubscriberController.php
@@ -1,0 +1,18 @@
+<?php
+class SubscriberController extends Controller {
+    public function discount() {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        if (!isset($_SESSION['user'])) {
+            $requestedUrl = $_SERVER['REQUEST_URI'] ?? BASE_URL;
+            $_SESSION['return_url'] = $requestedUrl;
+
+            header("Location: " . BASE_URL . "user/login");
+            exit;
+        }
+
+        // TODO: Implement discount form handling for logged-in users.
+    }
+}

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -25,6 +25,20 @@ class UserController extends Controller {
                         'role'  => $user['role']
                     ];
 
+                    if (!empty($_SESSION['return_url'])) {
+                        $redirectUrl = $_SESSION['return_url'];
+                        unset($_SESSION['return_url']);
+
+                        if (preg_match('#^https?://#i', $redirectUrl)) {
+                            header('Location: ' . $redirectUrl);
+                        } elseif (strpos($redirectUrl, '/') === 0) {
+                            header('Location: ' . $redirectUrl);
+                        } else {
+                            header('Location: ' . BASE_URL . ltrim($redirectUrl, '/'));
+                        }
+                        exit;
+                    }
+
                     // Điều hướng
                     if ($user['role'] === 'admin') {
                         header("Location: " . BASE_URL . "admin/dashboard");


### PR DESCRIPTION
## Summary
- add a SubscriberController gate that requires a logged-in session before accessing the discount form, saving the intended URL for later
- update the login workflow to redirect to the stored return URL once authentication succeeds before falling back to the default destinations

## Testing
- php -l controllers/SubscriberController.php
- php -l controllers/UserController.php

------
https://chatgpt.com/codex/tasks/task_e_68c90b151b9883268fb3437f93c5de76